### PR TITLE
Fix proxyImage regex

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -106,9 +106,9 @@ export const illustBookmarkDelete = (illustId: number | string) =>
   honoka.delete(`/v1/illust/bookmark/${illustId}`) as Promise<PixivResponse>;
 
 export const proxyImage = (url: string) => {
-  const regex = /^http?s:\/\/(i\.pximg\.net)|(source\.pixiv\.net)/i;
+  const regex = /^https?:\/\/(i\.pximg\.net)|(source\.pixiv\.net)/i;
   if (regex.test(url)) {
-    return `${config.apiBaseURL}/image/${url.replace(/^http?s:\/\//, '')}`;
+    return `${config.apiBaseURL}/image/${url.replace(/^https?:\/\//, '')}`;
   }
   return url;
 };


### PR DESCRIPTION
`http?s` means matching `p` is optional. While shifting the `?` to `https?` assumes `s` is optional.